### PR TITLE
change deprecated selector

### DIFF
--- a/lib/uniq-background.coffee
+++ b/lib/uniq-background.coffee
@@ -28,7 +28,7 @@ module.exports =
     image = document.createElement('img')
     image.className = 'uniq-image'
     image.src = src
-    view.shadowRoot.appendChild(image)
+    view.appendChild(image)
 
   srcForPath: (path)->
     number = parseInt(md5(path), 16)

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "repository": "https://github.com/negipo/uniq-background",
   "license": "MIT",
   "engines": {
-    "atom": ">=1.0"
+    "atom": ">=1.13"
   },
   "dependencies": {
     "blueimp-md5": "^1.1.1"

--- a/styles/uniq-background.less
+++ b/styles/uniq-background.less
@@ -1,4 +1,4 @@
-atom-text-editor::shadow {
+atom-text-editor.editor {
   .uniq-image {
     width: 500px;
     position: absolute;


### PR DESCRIPTION
This patch should get rid of the deprecation warning shown as of Atom version 1.13.